### PR TITLE
869690: Modify the image Editor Contextual toolbar sample in ts platform

### DIFF
--- a/ej2-javascript/code-snippet/image-editor/toolbar-template-cs2/index.js
+++ b/ej2-javascript/code-snippet/image-editor/toolbar-template-cs2/index.js
@@ -5,15 +5,12 @@ var imageEditorObj = new ej.imageeditor.ImageEditor({
     height: '350px',
      toolbarUpdating: function (args) {
         if (args.toolbarType === 'pen') {
-            for (let i = 0; i < args.toolbarItems.length; i++) {
-                if (args.toolbarItems[i].align === "Center") {
-                    if ((args.toolbarItems[i].tooltipText === "Stroke Width" || args.toolbarItems[i].tooltipText === "Remove") ||
-                        (args.toolbarItems[i].type && args.toolbarItems[i].type === 'Separator')) {
-                        args.toolbarItems[i].visible = false;
-                    }
+            args.toolbarItems.forEach(item => {
+                if (item.align === 'Center' && (item.tooltipText === 'Stroke Width' || item.tooltipText === 'Remove' || item.type === 'Separator')) {
+                    item.visible = false;
                 }
-            }
-        }
+            });
+        }            
      },
      created: function () {
         if (ej.base.Browser.isDevice) {

--- a/ej2-javascript/code-snippet/image-editor/toolbar-template-cs2/index.js
+++ b/ej2-javascript/code-snippet/image-editor/toolbar-template-cs2/index.js
@@ -4,9 +4,16 @@ var imageEditorObj = new ej.imageeditor.ImageEditor({
     width: '550px',
     height: '350px',
      toolbarUpdating: function (args) {
-         if (args.toolbarType === 'shapes') {
-             args.toolbarItems = ['strokeColor'];
-         }
+        if (args.toolbarType === 'pen') {
+            for (let i = 0; i < args.toolbarItems.length; i++) {
+                if (args.toolbarItems[i].align === "Center") {
+                    if ((args.toolbarItems[i].tooltipText === "Stroke Width" || args.toolbarItems[i].tooltipText === "Remove") ||
+                        (args.toolbarItems[i].type && args.toolbarItems[i].type === 'Separator')) {
+                        args.toolbarItems[i].visible = false;
+                    }
+                }
+            }
+        }
      },
      created: function () {
         if (ej.base.Browser.isDevice) {

--- a/ej2-javascript/code-snippet/image-editor/toolbar-template-cs2/index.ts
+++ b/ej2-javascript/code-snippet/image-editor/toolbar-template-cs2/index.ts
@@ -11,15 +11,12 @@ let imageEditorObj: ImageEditor = new ImageEditor({
     height: '350px',
     toolbarUpdating: (args: any) => {
         if (args.toolbarType === 'pen') {
-            for (let i: number = 0; i < args.toolbarItems.length; i++) {
-                if (args.toolbarItems[i as number].align === "Center") {
-                    if ((args.toolbarItems[i as number].tooltipText === "Stroke Width" || args.toolbarItems[i as number].tooltipText === "Remove") ||
-                        (args.toolbarItems[i as number].type && args.toolbarItems[i as number].type === 'Separator')) {
-                        args.toolbarItems[i as number].visible = false;
-                    }
+            args.toolbarItems.forEach(item => {
+                if (item.align === 'Center' && (item.tooltipText === 'Stroke Width' || item.tooltipText === 'Remove' || item.type === 'Separator')) {
+                    item.visible = false;
                 }
-            }
-        }
+            });
+        }            
     },
     created: () => {
         if (Browser.isDevice) {

--- a/ej2-javascript/code-snippet/image-editor/toolbar-template-cs2/index.ts
+++ b/ej2-javascript/code-snippet/image-editor/toolbar-template-cs2/index.ts
@@ -1,17 +1,17 @@
 
 
-import { ImageEditor } from '@syncfusion/ej2-image-editor';
+import { ImageEditor, ToolbarEventArgs } from '@syncfusion/ej2-image-editor';
 import { Browser } from '@syncfusion/ej2-base';
-
+import { ItemModel } from '@syncfusion/ej2-navigations';
 
 //Image Editor items definition
 
 let imageEditorObj: ImageEditor = new ImageEditor({
     width: '550px',
     height: '350px',
-    toolbarUpdating: (args: any) => {
+    toolbarUpdating: (args: ToolbarEventArgs) => {
         if (args.toolbarType === 'pen') {
-            args.toolbarItems.forEach(item => {
+            args.toolbarItems.forEach((item: ItemModel) => {
                 if (item.align === 'Center' && (item.tooltipText === 'Stroke Width' || item.tooltipText === 'Remove' || item.type === 'Separator')) {
                     item.visible = false;
                 }

--- a/ej2-javascript/code-snippet/image-editor/toolbar-template-cs2/index.ts
+++ b/ej2-javascript/code-snippet/image-editor/toolbar-template-cs2/index.ts
@@ -9,9 +9,16 @@ import { Browser } from '@syncfusion/ej2-base';
 let imageEditorObj: ImageEditor = new ImageEditor({
     width: '550px',
     height: '350px',
-    toolbarUpdating: (args: ToolbarEventArgs) => {
-        if (args.toolbarType === 'shapes') {
-            args.toolbarItems = ['strokeColor'];
+    toolbarUpdating: (args: any) => {
+        if (args.toolbarType === 'pen') {
+            for (let i: number = 0; i < args.toolbarItems.length; i++) {
+                if (args.toolbarItems[i as number].align === "Center") {
+                    if ((args.toolbarItems[i as number].tooltipText === "Stroke Width" || args.toolbarItems[i as number].tooltipText === "Remove") ||
+                        (args.toolbarItems[i as number].type && args.toolbarItems[i as number].type === 'Separator')) {
+                        args.toolbarItems[i as number].visible = false;
+                    }
+                }
+            }
         }
     },
     created: () => {


### PR DESCRIPTION
### Task description
Modify the image Editor Contextual toolbar sample in all platform

### Solution description
Updated the image editor  toolbar to show only stroke color icon while using pen annotation

### Is it a breaking issue?
* [ ]  Yes, Tag `breaking-issue`. 
* [X]  NO
 
 Is this common issue need to be addressed in the same component or on other components in our platform? 
* [ ]  Yes - Need to check in other components, tag `needs-attention-coreteam` 
* [X]  No
  
### Output screenshots
![image](https://github.com/syncfusion-content/ej2-image-editor-docs/assets/125449519/e97cf0c4-902d-41fb-af3f-ed58825e6968)


Is there any new API or existing API name change?
* [ ]  Yes. If yes, Provide API Review task link.
* [X]  NO
  
Is there any existing behavior change due to this code change?
* [ ]  Yes. Add `breaking-change` label.
* [X]  NO

Do the code changes cause any memory leak and performance issue? (Test only if you suspect that your code may cause problem)
* [ ]  Yes
* [X]  NO

### Reviewer Checklist
* [ ]  All provided information are reviewed and ensured.